### PR TITLE
fix: Cookie issues

### DIFF
--- a/src/routes/api/auth/logout.ts
+++ b/src/routes/api/auth/logout.ts
@@ -26,6 +26,7 @@ export async function get(req: Request): Promise<Response> {
 		return {
 			status: 200,
 			headers: {
+				'cache-control': 'no-store',
 				'set-cookie': cookie
 			},
 			body: {}

--- a/src/routes/api/auth/user.ts
+++ b/src/routes/api/auth/user.ts
@@ -20,6 +20,7 @@ export async function get(req: Request): Promise<Response> {
 		return {
 			status: 200,
 			headers: {
+        'cache-control': 'no-store',
 				'set-cookie': cookie
 			},
 			body: {


### PR DESCRIPTION
Logout endpoint needs a 'cache-control': 'no-store' because without it, the 'set-cookie' header will be removed by SvelteKit after the first logout (because the endpoint returns the same response each time): https://github.com/sveltejs/kit/blob/92d33913e284e00fb20d882253ba5439eeafc407/packages/kit/src/runtime/server/index.js#L61-L73

EDIT: Also added fix for existing SvelteKit issue where the `set-cookie` header is not add to the page response via `load()` (preventing session cookie from being refreshed). Temporary workaround is to just call `/api/auth/user` from client using `onMount`, the response headers aren't interfered with this way.

EDIT: I think this https://github.com/sveltejs/kit/issues/1198 is the bug that's causing the issue actually. 🤔