### PR TITLE
fix: Workaround for https://github.com/sveltejs/kit/issues/1198

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -20,6 +20,17 @@
 <script lang="ts">
 	import Header from '$lib/Header/index.svelte';
 	import '../app.css';
+  import { onMount } from 'svelte';
+
+  onMount(async () => {
+    // XXX: Temp workaround due to:
+    // https://github.com/sveltejs/kit/issues/1198
+    //
+    // Also see:
+    // https://github.com/sveltejs/kit/issues/696
+    // https://github.com/sveltejs/kit/issues/672
+    await fetch('/api/auth/user');
+  })
 </script>
 
 <Header />


### PR DESCRIPTION
Temporary fix for existing SvelteKit issue where the set-cookie header is not added to the page response via load() (preventing session cookie from being refreshed). Temporary workaround is to just call /api/auth/user from client using `onMount`, the response headers aren't interfered with this way.

https://github.com/sveltejs/kit/issues/1198